### PR TITLE
Fix typo in compiler target property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	</scm>
 	
 	<properties>
-		<maven.compiler.targer>17</maven.compiler.targer>
+                <maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>
 		<java.version>17</java.version>
 		<skipTests>true</skipTests>


### PR DESCRIPTION
## Summary
- fix typo in `pom.xml`'s `maven.compiler.target` property

## Testing
- `./mvnw -DskipTests package` *(fails: unable to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6874ebfd1cf48324a827ec42a8a5ce39